### PR TITLE
turn off hot reload for testing

### DIFF
--- a/start_api.py
+++ b/start_api.py
@@ -16,6 +16,6 @@ if __name__ == "__main__":
         "src.main:app",
         host="0.0.0.0",
         port=8000,
-        reload=True,  # Enable auto-reload during development
+        reload=False,  # Temporarily disable auto-reload
         log_level="info"
     )


### PR DESCRIPTION
@MAustin428 This allows the server to start up successfully.
You can run any non-db request against it now. I'm working on the DB requests.

<img width="2493" height="2072" alt="image" src="https://github.com/user-attachments/assets/a4ca1e59-a010-4ffd-b438-04d7076abd82" />
